### PR TITLE
Fix/transaction

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -32,15 +32,6 @@ create table session
 		foreign key (username) references user (username)
 );
 
-create table transaction
-(
-	id MEDIUMINT unsigned auto_increment,
-	last_modified timestamp default CURRENT_TIMESTAMP not null,
-	token char(36) not null,
-	constraint transaction_pk
-		primary key (id)
-);
-
 DELIMITER $$
 CREATE PROCEDURE CreateUser()
 BEGIN

--- a/schema.sql
+++ b/schema.sql
@@ -36,7 +36,6 @@ create table transaction
 (
 	id MEDIUMINT unsigned auto_increment,
 	last_modified timestamp default CURRENT_TIMESTAMP not null,
-	statement varchar(1000) default "" not null,
 	token char(36) not null,
 	constraint transaction_pk
 		primary key (id)

--- a/src/main/java/DbHelper.java
+++ b/src/main/java/DbHelper.java
@@ -463,12 +463,6 @@ public class DbHelper {
         }
     }
 
-    public static class ExecuteTransactionRejectedException extends ExecuteTransactionException {
-        ExecuteTransactionRejectedException(String s) {
-            super(s);
-        }
-    }
-
     public void executeTransaction(int transactionId, String token, boolean commit) throws ExecuteTransactionException {
         try {
             Connection conn = this.txConnectionMap.get(new ConnectionKey(transactionId, token));

--- a/src/main/java/DbHelper.java
+++ b/src/main/java/DbHelper.java
@@ -23,8 +23,6 @@ public class DbHelper {
 
     private MysqlDataSource ds;
 
-    // Properties & Constructor
-    private String dbUrl = "jdbc:mysql://localhost:3306/comp4111?user=comp4111&password=comp4111&useSSL=false";
     private static int TRANSACTION_TIMEOUT_SECONDS = 120;
 
     private DbHelper() throws Exception {
@@ -35,9 +33,11 @@ public class DbHelper {
         // Import Config
         try {
             String env = System.getenv("DB_URL");
+            // Properties & Constructor
+            String dbUrl = "jdbc:mysql://localhost:3306/comp4111?user=comp4111&password=comp4111&useSSL=false";
             if (env != null) dbUrl = "jdbc:" + env;
             this.ds = new MysqlDataSource();
-            this.ds.setUrl(this.dbUrl);
+            this.ds.setUrl(dbUrl);
         } catch (Exception e) {
             System.out.println("Failed to load db host from env, reverting to default");
         }

--- a/src/main/java/TransactionRequestHandler.java
+++ b/src/main/java/TransactionRequestHandler.java
@@ -137,8 +137,8 @@ public class TransactionRequestHandler implements HttpAsyncRequestHandler<HttpRe
             response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK);
             ObjectMapper mapper = new ObjectMapper();
             StringEntity body = new StringEntity(
-                mapper.writeValueAsString(responseBody),
-                ContentType.APPLICATION_JSON
+                    mapper.writeValueAsString(responseBody),
+                    ContentType.APPLICATION_JSON
             );
             response.setEntity(body);
         } catch (DbHelper.CreateTransactionException e) {
@@ -166,7 +166,7 @@ public class TransactionRequestHandler implements HttpAsyncRequestHandler<HttpRe
             return;
         }
 
-        if (requestBody.operation == TransactionOperation.COMMIT) {
+        if (requestBody.operation != null) {
             try {
                 DbHelper.getInstance().executeTransaction(requestBody.transactionId, token, requestBody.operation == TransactionOperation.COMMIT);
                 response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK);

--- a/src/main/java/TransactionRequestHandler.java
+++ b/src/main/java/TransactionRequestHandler.java
@@ -201,7 +201,7 @@ public class TransactionRequestHandler implements HttpAsyncRequestHandler<HttpRe
         try {
             DbHelper.getInstance().appendTransaction(requestBody.transactionId, token, requestBody.action, requestBody.bookId);
             response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK);
-        } catch (DbHelper.AppendTransactionNotFoundException | DbHelper.AppendTransactionInvalidException e) {
+        } catch (DbHelper.AppendTransactionNotFoundException | DbHelper.AppendTransactionInvalidException | DbHelper.AppendTransactionDeadlockException e) {
             response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_BAD_REQUEST);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/TransactionRequestHandler.java
+++ b/src/main/java/TransactionRequestHandler.java
@@ -168,24 +168,9 @@ public class TransactionRequestHandler implements HttpAsyncRequestHandler<HttpRe
 
         if (requestBody.operation == TransactionOperation.COMMIT) {
             try {
-                DbHelper.getInstance().executeTransaction(requestBody.transactionId, token);
+                DbHelper.getInstance().executeTransaction(requestBody.transactionId, token, requestBody.operation == TransactionOperation.COMMIT);
                 response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK);
-                try {
-                    DbHelper.getInstance().deleteTransaction(requestBody.transactionId, token);
-                } catch (Exception e) {
-                    System.out.println("Transaction delete failed after successful commit");
-                }
             } catch (DbHelper.ExecuteTransactionException e) {
-                response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_BAD_REQUEST);
-            } catch (Exception e) {
-                e.printStackTrace();
-                response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_INTERNAL_SERVER_ERROR);
-            }
-        } else if (requestBody.operation == TransactionOperation.CANCEL) {
-            try {
-                DbHelper.getInstance().deleteTransaction(requestBody.transactionId, token);
-                response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK);
-            } catch (DbHelper.DeleteTransactionNotFoundException e) {
                 response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_BAD_REQUEST);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/src/main/java/TransactionRequestHandler.java
+++ b/src/main/java/TransactionRequestHandler.java
@@ -201,7 +201,7 @@ public class TransactionRequestHandler implements HttpAsyncRequestHandler<HttpRe
         try {
             DbHelper.getInstance().appendTransaction(requestBody.transactionId, token, requestBody.action, requestBody.bookId);
             response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK);
-        } catch (DbHelper.AppendTransactionNotFoundException e) {
+        } catch (DbHelper.AppendTransactionNotFoundException | DbHelper.AppendTransactionInvalidException e) {
             response.setStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_BAD_REQUEST);
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Previous understanding ti XA transaction is wrong, which in fact can only maintain one transaction on one connection. Therefore this PR re-implements transaction using simple SQL transaction and maintains a connection map in memory.

- SQL Transaction with in memory connection map
- Transaction timeout using Java Timer
- Handles deadlock in transaction
- Updates SQL source

Note: Passed Phase 2 JMeter Test
